### PR TITLE
add logging of deactivate msgs

### DIFF
--- a/lib/nci/ncipacket.cpp
+++ b/lib/nci/ncipacket.cpp
@@ -26,10 +26,14 @@ const char* toString(nciMessageId messageId) {
             return "RF_DISCOVER_RSP";
         case nciMessageId::RF_DISCOVER_NTF:
             return "RF_DISCOVER_NTF";
-        case nciMessageId::RF_INTF_ACTIVATED_NTF:
-            return "RF_INTF_ACTIVATED_NTF";
+        case nciMessageId::RF_DEACTIVATE_CMD:
+            return "RF_DEACTIVATE_CMD";
         case nciMessageId::RF_DEACTIVATE_RSP:
             return "RF_DEACTIVATE_RSP";
+        case nciMessageId::RF_DEACTIVATE_NTF:
+            return "RF_DEACTIVATE_NTF";
+        case nciMessageId::RF_INTF_ACTIVATED_NTF:
+            return "RF_INTF_ACTIVATED_NTF";
         default:
             return "Unknown Message";
     }

--- a/lib/nci/ncipacket.hpp
+++ b/lib/nci/ncipacket.hpp
@@ -69,7 +69,7 @@ enum class nciMessageId : uint16_t {
 
     CORE_GET_CONFIG_CMD = (static_cast<uint16_t>(messageType::Command) | static_cast<uint16_t>(groupIdentifier::Core)) << 8 | static_cast<uint16_t>(opcodeIdentifier::CORE_GET_CONFIG_CMD),
     CORE_GET_CONFIG_RSP = (static_cast<uint16_t>(messageType::Response) | static_cast<uint16_t>(groupIdentifier::Core)) << 8 | static_cast<uint16_t>(opcodeIdentifier::CORE_GET_CONFIG_RSP),
-    
+
     CORE_SET_CONFIG_CMD = (static_cast<uint16_t>(messageType::Command) | static_cast<uint16_t>(groupIdentifier::Core)) << 8 | static_cast<uint16_t>(opcodeIdentifier::CORE_SET_CONFIG_CMD),
     CORE_SET_CONFIG_RSP = (static_cast<uint16_t>(messageType::Response) | static_cast<uint16_t>(groupIdentifier::Core)) << 8 | static_cast<uint16_t>(opcodeIdentifier::CORE_SET_CONFIG_RSP),
 
@@ -78,15 +78,15 @@ enum class nciMessageId : uint16_t {
     RF_DISCOVER_NTF = (static_cast<uint16_t>(messageType::Notification) | static_cast<uint16_t>(groupIdentifier::RfManagement)) << 8 | static_cast<uint16_t>(opcodeIdentifier::RF_DISCOVER_NTF),
 
     RF_INTF_ACTIVATED_NTF = (static_cast<uint16_t>(messageType::Notification) | static_cast<uint16_t>(groupIdentifier::RfManagement)) << 8 | static_cast<uint16_t>(opcodeIdentifier::RF_INTF_ACTIVATED_NTF),
-    RF_DEACTIVATE_RSP     = (static_cast<uint16_t>(messageType::Response) | static_cast<uint16_t>(groupIdentifier::RfManagement)) << 8 | static_cast<uint16_t>(opcodeIdentifier::RF_DEACTIVATE_RSP),
-    RF_DEACTIVATE_NTF     = (static_cast<uint16_t>(messageType::Notification) | static_cast<uint16_t>(groupIdentifier::RfManagement)) << 8 | static_cast<uint16_t>(opcodeIdentifier::RF_DEACTIVATE_NTF),
+
+    RF_DEACTIVATE_CMD = (static_cast<uint16_t>(messageType::Command) | static_cast<uint16_t>(groupIdentifier::RfManagement)) << 8 | static_cast<uint16_t>(opcodeIdentifier::RF_DEACTIVATE_CMD),
+    RF_DEACTIVATE_RSP = (static_cast<uint16_t>(messageType::Response) | static_cast<uint16_t>(groupIdentifier::RfManagement)) << 8 | static_cast<uint16_t>(opcodeIdentifier::RF_DEACTIVATE_RSP),
+    RF_DEACTIVATE_NTF = (static_cast<uint16_t>(messageType::Notification) | static_cast<uint16_t>(groupIdentifier::RfManagement)) << 8 | static_cast<uint16_t>(opcodeIdentifier::RF_DEACTIVATE_NTF),
 };
 
 const char* toString(nciMessageId messageId);
 
-
-
-enum class nciStatus : uint8_t{
+enum class nciStatus : uint8_t {
     // Generic Status Codes
     ok               = 0x00,
     rejected         = 0x01,

--- a/lib/version/buildinfo.cpp
+++ b/lib/version/buildinfo.cpp
@@ -10,8 +10,8 @@
 const buildEnvironment buildInfo::theBuildEnvironment{buildEnvironment::local};
 const buildType buildInfo::theBuildType{buildType::development};
 const int buildInfo::mainVersionDigit   = 1;
-const int buildInfo::minorVersionDigit  = 0;
-const int buildInfo::patchVersionDigit  = 1;
-const char* buildInfo::lastCommitTag    = "b5ee249";
-const char* buildInfo::buildTimeStamp   = "Sun Jan 12 10:33:33 2025";
-const time_t buildInfo::buildEpoch      = 1736678013;
+const int buildInfo::minorVersionDigit  = 1;
+const int buildInfo::patchVersionDigit  = 0;
+const char* buildInfo::lastCommitTag    = "25870c5";
+const char* buildInfo::buildTimeStamp   = "Mon Jan 13 08:30:52 2025";
+const time_t buildInfo::buildEpoch      = 1736757052;


### PR DESCRIPTION
some common RF_DEACTIVATE messages no longer shown as 'unknown message' in the NCUI message logging